### PR TITLE
fix: memory leak in javamds

### DIFF
--- a/conf/valgrind-mdsplus.supp
+++ b/conf/valgrind-mdsplus.supp
@@ -53,6 +53,21 @@
 }
 
 {
+   leak in threadsafe posix gethostbyname2_r (found in javamds)
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:__libc_alloc_buffer_allocate
+   fun:__resolv_conf_allocate
+   fun:__resolv_conf_load
+   fun:__resolv_conf_get_current
+   fun:__res_vinit
+   fun:maybe_init
+   fun:__resolv_context_get
+   fun:gethostbyname2_r@@GLIBC_2.2.5
+}
+
+{
    race conditions on fc26
    Helgrind:Race
    ...

--- a/java/mdsobjects/src/main/java/MDSplus/Tree.java
+++ b/java/mdsobjects/src/main/java/MDSplus/Tree.java
@@ -92,12 +92,12 @@ static public final int  TreeUSAGE_ANY  = 0,
 	    if(upMode.equals("EDIT"))
 	        editTree(name, shot, false);
 	    open = true;
-
 	}
 
 	public void close() throws MdsException
 	{
-	    closeTree(ctx1, ctx2, name, shot);
+	    if (this.isOpen())
+			closeTree(ctx1, ctx2, name, shot);
 	    open = false;
 	}
 
@@ -367,7 +367,11 @@ static public final int  TreeUSAGE_ANY  = 0,
 	 */
 	public void edit() throws MdsException
 	{
-	    editTree(name, shot, false);
+		if (this.mode.equals("EDIT") || this.mode.equals("NEW")) return;
+		if (this.isOpen()) this.close();		
+		editTree(name, shot, false);
+		this.open = true;
+		this.mode = "EDIT";
 	}
 
 	/**

--- a/java/mdsobjects/src/test/java/MDSplus/MdsConnectionTest.java
+++ b/java/mdsobjects/src/test/java/MDSplus/MdsConnectionTest.java
@@ -55,7 +55,8 @@ public class MdsConnectionTest{
 	@Before
 	public void setUp() throws Exception 
 	{
-	    freePort= 8888;
+	    freePort= 8889; // there could be some issues here as it seems that if the port is
+						// not actually available the test hangs.
 	    int count = 0;
             while(count < 100)
 	    {

--- a/java/mdsobjects/src/test/java/MDSplus/MdsTreeNodeTest.java
+++ b/java/mdsobjects/src/test/java/MDSplus/MdsTreeNodeTest.java
@@ -15,7 +15,6 @@ public class MdsTreeNodeTest{
 	private static MDSplus.Data data;
 
 
-
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception 
 	{
@@ -66,6 +65,7 @@ public class MdsTreeNodeTest{
 		Assert.assertEquals(node.getTree().getName(), tree2.getName());
 		Assert.assertEquals(node.getTree().getShot(), tree2.getShot());
 		node.setTree(tree);
+		tree2.close();
 
 	// getPath()
 		Assert.assertEquals("\\JAVA_TEST1::TOP:TEST_NODE" , node.getPath());
@@ -225,7 +225,6 @@ public class MdsTreeNodeTest{
 		Assert.assertEquals(2, test_structure.getDepth());
 		Assert.assertEquals(3, parent.getDepth());
  
-
 		tree.edit();
 		node = tree.addNode("test_flags","ANY");
 		Assert.assertEquals( false, node.isWriteOnce());
@@ -256,7 +255,6 @@ public class MdsTreeNodeTest{
 		Assert.assertEquals(true, node.isCompressOnPut() );
 
 	// NO WRITE ////////////////////////////////////////////////////////////
-
 		tree = new MDSplus.Tree("java_test1",-1);
 		tree.createPulse(1);
 
@@ -312,7 +310,8 @@ public class MdsTreeNodeTest{
 		node = shot.addNode("onlypulse","ANY");
 		node.setIncludedInPulse(true);
 		Assert.assertEquals(true, node.isIncludedInPulse() );
-
+		shot.write();
+		shot.close();
 
 		tree.edit();
 		tree.addNode("test_seg","STRUCTURE");
@@ -587,9 +586,12 @@ public class MdsTreeNodeTest{
 		}catch(Exception exc){}
 		n1.addDevice("device","DIO2");
 
+		tree.quit();
+
 	    }catch(Exception exc)
 	    {
-		Assert.fail(exc.toString());
+			exc.printStackTrace();
+			Assert.fail(exc.toString());
 	    }
       }
 }

--- a/java/mdsobjects/src/test/java/MDSplus/MdsTreeTest.java
+++ b/java/mdsobjects/src/test/java/MDSplus/MdsTreeTest.java
@@ -44,12 +44,14 @@ public class MdsTreeTest{
 		tree = new MDSplus.Tree("java_test0",-1,"READONLY");
 		Assert.assertEquals(true, tree.isReadOnly() );
 		tree.close();
+		tree.close();
+		tree.edit();
+		tree.close();
 		tree = new MDSplus.Tree("java_test0",-1,"EDIT");
 		Assert.assertEquals(true, tree.isOpenForEdit() );
 		tree.close();
     // write to parse file node usages //
-		tree = new MDSplus.Tree("java_test0",-1,"NORMAL");
-		tree.edit();
+		tree = new MDSplus.Tree("java_test0",-1,"EDIT");
 		MDSplus.TreeNode node = tree.addNode("test_usage","STRUCTURE");
 
 	// fill all kinds of nodes into the test_usage structure //
@@ -66,7 +68,7 @@ public class MdsTreeTest{
 		node = tree.addNode("\\java_test0::top.test_usage:TEXT","TEXT");
 		node = tree.addNode("\\java_test0::top.test_usage:WINDOW","WINDOW");
 		tree.write();
-
+		tree.close();
 		tree = new MDSplus.Tree("java_test0",-1,"READONLY");
 		node = tree.getNode("\\java_test0::top.test_usage:ANY");
 		Assert.assertEquals("ANY", node.getNodeName());
@@ -134,7 +136,7 @@ public class MdsTreeTest{
 		Assert.assertEquals(1, array.size());
 		Assert.assertEquals("WINDOW", array.getElementAt(0).getNodeName());
 
- 
+		tree.close();
 		tree = new MDSplus.Tree("java_test0",-1,"NORMAL");
 
 		try {
@@ -154,17 +156,18 @@ public class MdsTreeTest{
 		tree.write();
 		Assert.assertEquals(false, tree.isModified() );
 
-		tree.addNode("save_me_not","ANY");
 	// it does not writes here //
-
 	// tests that the node has not been written
+		tree.write();
+		tree.close();
 		tree = new MDSplus.Tree("java_test0",-1,"NORMAL");
 		try {
-		    tree.getNode("save_me_not");
+			tree.addNode("save_me_not","ANY");
 		    Assert.fail("Node added in tree open in non edit mode");
 		}catch(Exception exc){}
 
      // add device
+		tree.close();
 		tree = new MDSplus.Tree("java_test0",-1,"EDIT");
 		tree.addDevice("device","DIO2");
 		tree.write();
@@ -180,17 +183,22 @@ public class MdsTreeTest{
 		}catch(Exception exc){}
 
        // create and delete
+	    tree.close();
 		tree = new MDSplus.Tree("java_test0",-1);
 		tree.createPulse(1);
+		tree.close();
 		tree = new MDSplus.Tree("java_test0",1);
 		node = tree.getNode("test_usage:ANY");
 		Assert.assertEquals("ANY", node.getNodeName());
+		tree.close();
 		tree = new MDSplus.Tree("java_test0",-1);
 		tree.createPulse(2);
+		tree.close();
 		tree = new MDSplus.Tree("java_test0",2);
 		tree.deletePulse(2);
 
 	// create a pulse without copying from model structure //
+		tree.close();
 		tree = new MDSplus.Tree("java_test0",2,"NEW");
 		  
 	// test that the new pulse has not the model nodes //
@@ -248,9 +256,13 @@ public class MdsTreeTest{
 		  Assert.fail("Tag test_tag found even if removed");
 		}catch(Exception exc){}
 
+		tree.write();
+		tree.close();
+
 	    }catch(Exception exc)
 	    {
-		Assert.fail(exc.toString());
+			exc.printStackTrace();
+			Assert.fail(exc.toString());
 	    }
       }
 }

--- a/java/mdsobjects/tests/Makefile.am
+++ b/java/mdsobjects/tests/Makefile.am
@@ -29,6 +29,9 @@ mdsip.sh: $(java_srcdir)/MDSplus/mdsip.sh
 MOSTLYCLEANFILES = *.tree *.datafile *.characteristics mdsip.sh
 
 tests: mdsip.sh
+tests-valgrind: mdsip.sh
+tests-valgrind-suppressions: mdsip.sh
+
 
 MAIN_JARS = mdsobjects.jar
 
@@ -48,19 +51,21 @@ TESTS = \
  MDSplus.MdsStringTest\
  MDSplus.MdsTreeNodeTest\
  MDSplus.MdsTreeTest\
- MDSplus.MdsWindowTest
-VALGRIND_TESTS = \
- MDSplus.MdsDataTest\
- MDSplus.MdsConglomTest\
- MDSplus.MdsConnectionTest\
- MDSplus.MdsDimensionTest\
- MDSplus.MdsEventTest\
- MDSplus.MdsExpressionCompileTest\
- MDSplus.MdsFunctionTest\
- MDSplus.MdsRangeTest\
- MDSplus.MdsSignalTest\
- MDSplus.MdsStringTest\
- MDSplus.MdsWindowTest
+ MDSplus.MdsWindowTest 
+ 
+
+# VALGRIND_TESTS = \
+#  MDSplus.MdsDataTest\
+#  MDSplus.MdsConglomTest\
+#  MDSplus.MdsConnectionTest\
+#  MDSplus.MdsDimensionTest\
+#  MDSplus.MdsEventTest\
+#  MDSplus.MdsExpressionCompileTest\
+#  MDSplus.MdsFunctionTest\
+#  MDSplus.MdsRangeTest\
+#  MDSplus.MdsSignalTest\
+#  MDSplus.MdsStringTest\
+#  MDSplus.MdsWindowTest
 
 # test_path = $(abs_builddir)/trees
 # hostfile = $(abs_top_srcdir)/testing/multi.hosts

--- a/java/mdsobjects/tests/Makefile.in
+++ b/java/mdsobjects/tests/Makefile.in
@@ -762,20 +762,7 @@ TESTS = \
  MDSplus.MdsStringTest\
  MDSplus.MdsTreeNodeTest\
  MDSplus.MdsTreeTest\
- MDSplus.MdsWindowTest
-
-VALGRIND_TESTS = \
- MDSplus.MdsDataTest\
- MDSplus.MdsConglomTest\
- MDSplus.MdsConnectionTest\
- MDSplus.MdsDimensionTest\
- MDSplus.MdsEventTest\
- MDSplus.MdsExpressionCompileTest\
- MDSplus.MdsFunctionTest\
- MDSplus.MdsRangeTest\
- MDSplus.MdsSignalTest\
- MDSplus.MdsStringTest\
- MDSplus.MdsWindowTest
+ MDSplus.MdsWindowTest 
 
 all: all-am
 
@@ -1509,6 +1496,21 @@ mdsip.sh: $(java_srcdir)/MDSplus/mdsip.sh
 	cp $< $@
 
 tests: mdsip.sh
+tests-valgrind: mdsip.sh
+tests-valgrind-suppressions: mdsip.sh
+
+# VALGRIND_TESTS = \
+#  MDSplus.MdsDataTest\
+#  MDSplus.MdsConglomTest\
+#  MDSplus.MdsConnectionTest\
+#  MDSplus.MdsDimensionTest\
+#  MDSplus.MdsEventTest\
+#  MDSplus.MdsExpressionCompileTest\
+#  MDSplus.MdsFunctionTest\
+#  MDSplus.MdsRangeTest\
+#  MDSplus.MdsSignalTest\
+#  MDSplus.MdsStringTest\
+#  MDSplus.MdsWindowTest
 
 # test_path = $(abs_builddir)/trees
 # hostfile = $(abs_top_srcdir)/testing/multi.hosts

--- a/javamds/mdsobjects.c
+++ b/javamds/mdsobjects.c
@@ -1844,6 +1844,7 @@ JNIEXPORT void JNICALL Java_MDSplus_Tree_closeTree
   ctx = getCtx(ctx1, ctx2);
   status = _TreeClose(&ctx, (char *)name, shot);
   (*env)->ReleaseStringUTFChars(env, jname, name);
+  TreeFreeDbid(ctx);
   if STATUS_NOT_OK {
     throwMdsException(env, status);
   }


### PR DESCRIPTION
- The dbid was not correctly freed in tree close
- All tests have been added back to valgrind memcheck
  a further suppression has been added to cope with a
  leak from mdstcpip when java call MdsConnect